### PR TITLE
Replace `container-title`

### DIFF
--- a/_posts/2019-04-11-abbasi-yadkori19a.md
+++ b/_posts/2019-04-11-abbasi-yadkori19a.md
@@ -35,7 +35,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-ablin19a.md
+++ b/_posts/2019-04-11-ablin19a.md
@@ -37,7 +37,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-acharya19a.md
+++ b/_posts/2019-04-11-acharya19a.md
@@ -39,7 +39,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-acharya19b.md
+++ b/_posts/2019-04-11-acharya19b.md
@@ -37,7 +37,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-adolphs19a.md
+++ b/_posts/2019-04-11-adolphs19a.md
@@ -33,7 +33,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-aglietti19a.md
+++ b/_posts/2019-04-11-aglietti19a.md
@@ -32,7 +32,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-agrawal19a.md
+++ b/_posts/2019-04-11-agrawal19a.md
@@ -41,7 +41,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-agrawal19b.md
+++ b/_posts/2019-04-11-agrawal19b.md
@@ -42,7 +42,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-ali19a.md
+++ b/_posts/2019-04-11-ali19a.md
@@ -34,7 +34,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-alvarez-melis19a.md
+++ b/_posts/2019-04-11-alvarez-melis19a.md
@@ -35,7 +35,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-alvarez19a.md
+++ b/_posts/2019-04-11-alvarez19a.md
@@ -30,7 +30,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-amari19a.md
+++ b/_posts/2019-04-11-amari19a.md
@@ -33,7 +33,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-ambrogioni19a.md
+++ b/_posts/2019-04-11-ambrogioni19a.md
@@ -48,7 +48,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-ambrogioni19b.md
+++ b/_posts/2019-04-11-ambrogioni19b.md
@@ -40,7 +40,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-amid19a.md
+++ b/_posts/2019-04-11-amid19a.md
@@ -41,7 +41,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-anari19a.md
+++ b/_posts/2019-04-11-anari19a.md
@@ -43,7 +43,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-andrade19a.md
+++ b/_posts/2019-04-11-andrade19a.md
@@ -33,7 +33,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-ardywibowo19a.md
+++ b/_posts/2019-04-11-ardywibowo19a.md
@@ -48,7 +48,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-arvanitidis19a.md
+++ b/_posts/2019-04-11-arvanitidis19a.md
@@ -35,7 +35,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-asi19a.md
+++ b/_posts/2019-04-11-asi19a.md
@@ -32,7 +32,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-atan19a.md
+++ b/_posts/2019-04-11-atan19a.md
@@ -37,7 +37,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-banijamali19a.md
+++ b/_posts/2019-04-11-banijamali19a.md
@@ -40,7 +40,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-barnes19a.md
+++ b/_posts/2019-04-11-barnes19a.md
@@ -36,7 +36,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-bascol19a.md
+++ b/_posts/2019-04-11-bascol19a.md
@@ -40,7 +40,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-bassily19a.md
+++ b/_posts/2019-04-11-bassily19a.md
@@ -37,7 +37,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-bauer19a.md
+++ b/_posts/2019-04-11-bauer19a.md
@@ -29,7 +29,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-bauer19b.md
+++ b/_posts/2019-04-11-bauer19b.md
@@ -38,7 +38,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-belkin19a.md
+++ b/_posts/2019-04-11-belkin19a.md
@@ -24,7 +24,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-bellemare19a.md
+++ b/_posts/2019-04-11-bellemare19a.md
@@ -38,7 +38,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-bellot19a.md
+++ b/_posts/2019-04-11-bellot19a.md
@@ -35,7 +35,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-berthet19a.md
+++ b/_posts/2019-04-11-berthet19a.md
@@ -29,7 +29,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-berthet19b.md
+++ b/_posts/2019-04-11-berthet19b.md
@@ -27,7 +27,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-bird19a.md
+++ b/_posts/2019-04-11-bird19a.md
@@ -29,7 +29,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-blonde19a.md
+++ b/_posts/2019-04-11-blonde19a.md
@@ -32,7 +32,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-blondel19a.md
+++ b/_posts/2019-04-11-blondel19a.md
@@ -31,7 +31,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-bollapragada19a.md
+++ b/_posts/2019-04-11-bollapragada19a.md
@@ -31,7 +31,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-brault19a.md
+++ b/_posts/2019-04-11-brault19a.md
@@ -39,7 +39,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-bu19a.md
+++ b/_posts/2019-04-11-bu19a.md
@@ -36,7 +36,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-cao19a.md
+++ b/_posts/2019-04-11-cao19a.md
@@ -38,7 +38,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-cardoso19a.md
+++ b/_posts/2019-04-11-cardoso19a.md
@@ -26,7 +26,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-cardoso19b.md
+++ b/_posts/2019-04-11-cardoso19b.md
@@ -30,7 +30,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-carter19a.md
+++ b/_posts/2019-04-11-carter19a.md
@@ -39,7 +39,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-chai19a.md
+++ b/_posts/2019-04-11-chai19a.md
@@ -31,7 +31,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-chang19a.md
+++ b/_posts/2019-04-11-chang19a.md
@@ -30,7 +30,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-charikar19a.md
+++ b/_posts/2019-04-11-charikar19a.md
@@ -35,7 +35,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-charles19a.md
+++ b/_posts/2019-04-11-charles19a.md
@@ -37,7 +37,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-chen19a.md
+++ b/_posts/2019-04-11-chen19a.md
@@ -46,7 +46,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-chen19b.md
+++ b/_posts/2019-04-11-chen19b.md
@@ -36,7 +36,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-chen19c.md
+++ b/_posts/2019-04-11-chen19c.md
@@ -33,7 +33,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-chen19d.md
+++ b/_posts/2019-04-11-chen19d.md
@@ -30,7 +30,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-chen19e.md
+++ b/_posts/2019-04-11-chen19e.md
@@ -31,7 +31,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-chen19f.md
+++ b/_posts/2019-04-11-chen19f.md
@@ -28,7 +28,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-chen19g.md
+++ b/_posts/2019-04-11-chen19g.md
@@ -36,7 +36,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-cheng19a.md
+++ b/_posts/2019-04-11-cheng19a.md
@@ -38,7 +38,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-cheung19a.md
+++ b/_posts/2019-04-11-cheung19a.md
@@ -34,7 +34,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-cheung19b.md
+++ b/_posts/2019-04-11-cheung19b.md
@@ -29,7 +29,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-chien19a.md
+++ b/_posts/2019-04-11-chien19a.md
@@ -30,7 +30,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-chierichetti19a.md
+++ b/_posts/2019-04-11-chierichetti19a.md
@@ -33,7 +33,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-cho19a.md
+++ b/_posts/2019-04-11-cho19a.md
@@ -34,7 +34,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-choromanski19a.md
+++ b/_posts/2019-04-11-choromanski19a.md
@@ -40,7 +40,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-chowdhury19a.md
+++ b/_posts/2019-04-11-chowdhury19a.md
@@ -32,7 +32,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-clertant19a.md
+++ b/_posts/2019-04-11-clertant19a.md
@@ -32,7 +32,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-cohen19a.md
+++ b/_posts/2019-04-11-cohen19a.md
@@ -33,7 +33,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-cortes19a.md
+++ b/_posts/2019-04-11-cortes19a.md
@@ -39,7 +39,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-croce19a.md
+++ b/_posts/2019-04-11-croce19a.md
@@ -30,7 +30,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-cucuringu19a.md
+++ b/_posts/2019-04-11-cucuringu19a.md
@@ -36,7 +36,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-czarnecki19a.md
+++ b/_posts/2019-04-11-czarnecki19a.md
@@ -41,7 +41,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-d-amour19a.md
+++ b/_posts/2019-04-11-d-amour19a.md
@@ -29,7 +29,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-dai19a.md
+++ b/_posts/2019-04-11-dai19a.md
@@ -42,7 +42,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-dai19b.md
+++ b/_posts/2019-04-11-dai19b.md
@@ -27,7 +27,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-dedieu19a.md
+++ b/_posts/2019-04-11-dedieu19a.md
@@ -29,7 +29,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-degenne19a.md
+++ b/_posts/2019-04-11-degenne19a.md
@@ -36,7 +36,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-delgosha19a.md
+++ b/_posts/2019-04-11-delgosha19a.md
@@ -36,7 +36,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-derezinski19a.md
+++ b/_posts/2019-04-11-derezinski19a.md
@@ -31,7 +31,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-deshpande19a.md
+++ b/_posts/2019-04-11-deshpande19a.md
@@ -40,7 +40,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-dev19a.md
+++ b/_posts/2019-04-11-dev19a.md
@@ -28,7 +28,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-dieng19a.md
+++ b/_posts/2019-04-11-dieng19a.md
@@ -41,7 +41,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-dieng19b.md
+++ b/_posts/2019-04-11-dieng19b.md
@@ -39,7 +39,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-dikov19a.md
+++ b/_posts/2019-04-11-dikov19a.md
@@ -27,7 +27,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-ding19a.md
+++ b/_posts/2019-04-11-ding19a.md
@@ -36,7 +36,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-dong19a.md
+++ b/_posts/2019-04-11-dong19a.md
@@ -35,7 +35,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-du19a.md
+++ b/_posts/2019-04-11-du19a.md
@@ -31,7 +31,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-du19b.md
+++ b/_posts/2019-04-11-du19b.md
@@ -32,7 +32,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-dubois19a.md
+++ b/_posts/2019-04-11-dubois19a.md
@@ -32,7 +32,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-dupont19a.md
+++ b/_posts/2019-04-11-dupont19a.md
@@ -27,7 +27,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-durrande19a.md
+++ b/_posts/2019-04-11-durrande19a.md
@@ -37,7 +37,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-eggeling19a.md
+++ b/_posts/2019-04-11-eggeling19a.md
@@ -36,7 +36,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-esmaeili19a.md
+++ b/_posts/2019-04-11-esmaeili19a.md
@@ -49,7 +49,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-esmaeili19b.md
+++ b/_posts/2019-04-11-esmaeili19b.md
@@ -37,7 +37,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-fadili19a.md
+++ b/_posts/2019-04-11-fadili19a.md
@@ -38,7 +38,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-falorsi19a.md
+++ b/_posts/2019-04-11-falorsi19a.md
@@ -37,7 +37,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-fan19a.md
+++ b/_posts/2019-04-11-fan19a.md
@@ -38,7 +38,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-fan19b.md
+++ b/_posts/2019-04-11-fan19b.md
@@ -37,7 +37,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-feng19a.md
+++ b/_posts/2019-04-11-feng19a.md
@@ -33,7 +33,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-fernandez19a.md
+++ b/_posts/2019-04-11-fernandez19a.md
@@ -30,7 +30,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-feydy19a.md
+++ b/_posts/2019-04-11-feydy19a.md
@@ -41,7 +41,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-fontaine19a.md
+++ b/_posts/2019-04-11-fontaine19a.md
@@ -30,7 +30,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-forrow19a.md
+++ b/_posts/2019-04-11-forrow19a.md
@@ -37,7 +37,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-frongillo19a.md
+++ b/_posts/2019-04-11-frongillo19a.md
@@ -35,7 +35,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-gaboardi19a.md
+++ b/_posts/2019-04-11-gaboardi19a.md
@@ -30,7 +30,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-gao19a.md
+++ b/_posts/2019-04-11-gao19a.md
@@ -37,7 +37,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-gao19b.md
+++ b/_posts/2019-04-11-gao19b.md
@@ -37,7 +37,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-garber19a.md
+++ b/_posts/2019-04-11-garber19a.md
@@ -39,7 +39,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-garber19b.md
+++ b/_posts/2019-04-11-garber19b.md
@@ -36,7 +36,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-garg19a.md
+++ b/_posts/2019-04-11-garg19a.md
@@ -29,7 +29,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-gasthaus19a.md
+++ b/_posts/2019-04-11-gasthaus19a.md
@@ -40,7 +40,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-genevay19a.md
+++ b/_posts/2019-04-11-genevay19a.md
@@ -44,7 +44,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-geng19a.md
+++ b/_posts/2019-04-11-geng19a.md
@@ -37,7 +37,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-ghadiri19a.md
+++ b/_posts/2019-04-11-ghadiri19a.md
@@ -37,7 +37,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-gidel19a.md
+++ b/_posts/2019-04-11-gidel19a.md
@@ -41,7 +41,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-gimenez19a.md
+++ b/_posts/2019-04-11-gimenez19a.md
@@ -38,7 +38,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-gimenez19b.md
+++ b/_posts/2019-04-11-gimenez19b.md
@@ -36,7 +36,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-giordano19a.md
+++ b/_posts/2019-04-11-giordano19a.md
@@ -46,7 +46,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-goel19a.md
+++ b/_posts/2019-04-11-goel19a.md
@@ -30,7 +30,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-grave19a.md
+++ b/_posts/2019-04-11-grave19a.md
@@ -35,7 +35,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-grover19a.md
+++ b/_posts/2019-04-11-grover19a.md
@@ -33,7 +33,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-hainline19a.md
+++ b/_posts/2019-04-11-hainline19a.md
@@ -40,7 +40,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-hanneke19a.md
+++ b/_posts/2019-04-11-hanneke19a.md
@@ -30,7 +30,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-hanzely19a.md
+++ b/_posts/2019-04-11-hanzely19a.md
@@ -37,7 +37,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-harutyunyan19a.md
+++ b/_posts/2019-04-11-harutyunyan19a.md
@@ -39,7 +39,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-he19a.md
+++ b/_posts/2019-04-11-he19a.md
@@ -31,7 +31,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-hegde19a.md
+++ b/_posts/2019-04-11-hegde19a.md
@@ -30,7 +30,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-hendrikx19a.md
+++ b/_posts/2019-04-11-hendrikx19a.md
@@ -38,7 +38,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-hiranandani19a.md
+++ b/_posts/2019-04-11-hiranandani19a.md
@@ -34,7 +34,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-hirt19a.md
+++ b/_posts/2019-04-11-hirt19a.md
@@ -31,7 +31,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-ho19a.md
+++ b/_posts/2019-04-11-ho19a.md
@@ -33,7 +33,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-holland19a.md
+++ b/_posts/2019-04-11-holland19a.md
@@ -24,7 +24,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-holland19b.md
+++ b/_posts/2019-04-11-holland19b.md
@@ -24,7 +24,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-hollocou19a.md
+++ b/_posts/2019-04-11-hollocou19a.md
@@ -32,7 +32,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-hsu19a.md
+++ b/_posts/2019-04-11-hsu19a.md
@@ -34,7 +34,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-hsu19b.md
+++ b/_posts/2019-04-11-hsu19b.md
@@ -36,7 +36,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-huggins19a.md
+++ b/_posts/2019-04-11-huggins19a.md
@@ -39,7 +39,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-huyuk19a.md
+++ b/_posts/2019-04-11-huyuk19a.md
@@ -31,7 +31,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-hyvarinen19a.md
+++ b/_posts/2019-04-11-hyvarinen19a.md
@@ -35,7 +35,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-imaizumi19a.md
+++ b/_posts/2019-04-11-imaizumi19a.md
@@ -33,7 +33,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-inoue19a.md
+++ b/_posts/2019-04-11-inoue19a.md
@@ -35,7 +35,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-iyer19a.md
+++ b/_posts/2019-04-11-iyer19a.md
@@ -35,7 +35,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-iyer19b.md
+++ b/_posts/2019-04-11-iyer19b.md
@@ -37,7 +37,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-jaghargh19a.md
+++ b/_posts/2019-04-11-jaghargh19a.md
@@ -33,7 +33,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-janati19a.md
+++ b/_posts/2019-04-11-janati19a.md
@@ -41,7 +41,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-jang19a.md
+++ b/_posts/2019-04-11-jang19a.md
@@ -31,7 +31,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-jankowiak19a.md
+++ b/_posts/2019-04-11-jankowiak19a.md
@@ -28,7 +28,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-jia19a.md
+++ b/_posts/2019-04-11-jia19a.md
@@ -48,7 +48,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-jiang19a.md
+++ b/_posts/2019-04-11-jiang19a.md
@@ -26,7 +26,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-johansson19a.md
+++ b/_posts/2019-04-11-johansson19a.md
@@ -34,7 +34,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-jung19a.md
+++ b/_posts/2019-04-11-jung19a.md
@@ -29,7 +29,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-kallus19a.md
+++ b/_posts/2019-04-11-kallus19a.md
@@ -36,7 +36,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-kamiya19a.md
+++ b/_posts/2019-04-11-kamiya19a.md
@@ -33,7 +33,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-karakida19a.md
+++ b/_posts/2019-04-11-karakida19a.md
@@ -36,7 +36,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-kargas19a.md
+++ b/_posts/2019-04-11-kargas19a.md
@@ -31,7 +31,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-karimireddy19a.md
+++ b/_posts/2019-04-11-karimireddy19a.md
@@ -37,7 +37,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-karoui19a.md
+++ b/_posts/2019-04-11-karoui19a.md
@@ -27,7 +27,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-katariya19a.md
+++ b/_posts/2019-04-11-katariya19a.md
@@ -35,7 +35,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-katz-samuels19a.md
+++ b/_posts/2019-04-11-katz-samuels19a.md
@@ -34,7 +34,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-katz19a.md
+++ b/_posts/2019-04-11-katz19a.md
@@ -37,7 +37,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-kazlauskaite19a.md
+++ b/_posts/2019-04-11-kazlauskaite19a.md
@@ -32,7 +32,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-kelly19a.md
+++ b/_posts/2019-04-11-kelly19a.md
@@ -37,7 +37,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-kerdreux19a.md
+++ b/_posts/2019-04-11-kerdreux19a.md
@@ -33,7 +33,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-khanna19a.md
+++ b/_posts/2019-04-11-khanna19a.md
@@ -36,7 +36,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-kleinegesse19a.md
+++ b/_posts/2019-04-11-kleinegesse19a.md
@@ -33,7 +33,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-ko19a.md
+++ b/_posts/2019-04-11-ko19a.md
@@ -29,7 +29,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-kohler19a.md
+++ b/_posts/2019-04-11-kohler19a.md
@@ -45,7 +45,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-kozuno19a.md
+++ b/_posts/2019-04-11-kozuno19a.md
@@ -35,7 +35,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-kugelgen19a.md
+++ b/_posts/2019-04-11-kugelgen19a.md
@@ -34,7 +34,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-kushagra19a.md
+++ b/_posts/2019-04-11-kushagra19a.md
@@ -42,7 +42,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-kushnir19a.md
+++ b/_posts/2019-04-11-kushnir19a.md
@@ -42,7 +42,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-kuzborskij19a.md
+++ b/_posts/2019-04-11-kuzborskij19a.md
@@ -33,7 +33,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-kuzelka19a.md
+++ b/_posts/2019-04-11-kuzelka19a.md
@@ -24,7 +24,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-lacotte19a.md
+++ b/_posts/2019-04-11-lacotte19a.md
@@ -35,7 +35,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-laforgue19a.md
+++ b/_posts/2019-04-11-laforgue19a.md
@@ -34,7 +34,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-lang19a.md
+++ b/_posts/2019-04-11-lang19a.md
@@ -31,7 +31,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-lapanowski19a.md
+++ b/_posts/2019-04-11-lapanowski19a.md
@@ -27,7 +27,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-laude19a.md
+++ b/_posts/2019-04-11-laude19a.md
@@ -36,7 +36,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-lee19a.md
+++ b/_posts/2019-04-11-lee19a.md
@@ -36,7 +36,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-lee19b.md
+++ b/_posts/2019-04-11-lee19b.md
@@ -36,7 +36,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-lejeune19a.md
+++ b/_posts/2019-04-11-lejeune19a.md
@@ -31,7 +31,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-lessard19a.md
+++ b/_posts/2019-04-11-lessard19a.md
@@ -34,7 +34,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-letarte19a.md
+++ b/_posts/2019-04-11-letarte19a.md
@@ -31,7 +31,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-levy19a.md
+++ b/_posts/2019-04-11-levy19a.md
@@ -29,7 +29,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-li19a.md
+++ b/_posts/2019-04-11-li19a.md
@@ -35,7 +35,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-li19b.md
+++ b/_posts/2019-04-11-li19b.md
@@ -39,7 +39,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-li19c.md
+++ b/_posts/2019-04-11-li19c.md
@@ -31,7 +31,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-li19d.md
+++ b/_posts/2019-04-11-li19d.md
@@ -35,7 +35,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-li19e.md
+++ b/_posts/2019-04-11-li19e.md
@@ -38,7 +38,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-li19f.md
+++ b/_posts/2019-04-11-li19f.md
@@ -41,7 +41,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-li19g.md
+++ b/_posts/2019-04-11-li19g.md
@@ -41,7 +41,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-li19h.md
+++ b/_posts/2019-04-11-li19h.md
@@ -36,7 +36,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-lian19a.md
+++ b/_posts/2019-04-11-lian19a.md
@@ -34,7 +34,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-liang19a.md
+++ b/_posts/2019-04-11-liang19a.md
@@ -34,7 +34,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-liang19b.md
+++ b/_posts/2019-04-11-liang19b.md
@@ -35,7 +35,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-lin19a.md
+++ b/_posts/2019-04-11-lin19a.md
@@ -37,7 +37,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-lin19b.md
+++ b/_posts/2019-04-11-lin19b.md
@@ -43,7 +43,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-liu19a.md
+++ b/_posts/2019-04-11-liu19a.md
@@ -41,7 +41,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-liu19b.md
+++ b/_posts/2019-04-11-liu19b.md
@@ -33,7 +33,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-liu19c.md
+++ b/_posts/2019-04-11-liu19c.md
@@ -35,7 +35,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-locatelli19a.md
+++ b/_posts/2019-04-11-locatelli19a.md
@@ -30,7 +30,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-lopez-lopera19a.md
+++ b/_posts/2019-04-11-lopez-lopera19a.md
@@ -33,7 +33,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-louppe19a.md
+++ b/_posts/2019-04-11-louppe19a.md
@@ -35,7 +35,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-ma19a.md
+++ b/_posts/2019-04-11-ma19a.md
@@ -31,7 +31,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-ma19b.md
+++ b/_posts/2019-04-11-ma19b.md
@@ -41,7 +41,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-madjiheurem19a.md
+++ b/_posts/2019-04-11-madjiheurem19a.md
@@ -29,7 +29,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-malik19a.md
+++ b/_posts/2019-04-11-malik19a.md
@@ -39,7 +39,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-malinsky19a.md
+++ b/_posts/2019-04-11-malinsky19a.md
@@ -27,7 +27,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-malinsky19b.md
+++ b/_posts/2019-04-11-malinsky19b.md
@@ -34,7 +34,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-mallasto19a.md
+++ b/_posts/2019-04-11-mallasto19a.md
@@ -36,7 +36,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-mangoubi19a.md
+++ b/_posts/2019-04-11-mangoubi19a.md
@@ -31,7 +31,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-mariet19a.md
+++ b/_posts/2019-04-11-mariet19a.md
@@ -26,7 +26,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-mariet19b.md
+++ b/_posts/2019-04-11-mariet19b.md
@@ -36,7 +36,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-mark19a.md
+++ b/_posts/2019-04-11-mark19a.md
@@ -37,7 +37,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-martens19a.md
+++ b/_posts/2019-04-11-martens19a.md
@@ -32,7 +32,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-marx19a.md
+++ b/_posts/2019-04-11-marx19a.md
@@ -30,7 +30,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-matsuda19a.md
+++ b/_posts/2019-04-11-matsuda19a.md
@@ -30,7 +30,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-middleton19a.md
+++ b/_posts/2019-04-11-middleton19a.md
@@ -35,7 +35,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-mittal19a.md
+++ b/_posts/2019-04-11-mittal19a.md
@@ -40,7 +40,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-miyaguchi19a.md
+++ b/_posts/2019-04-11-miyaguchi19a.md
@@ -29,7 +29,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-mokhtari19a.md
+++ b/_posts/2019-04-11-mokhtari19a.md
@@ -38,7 +38,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-molchanov19a.md
+++ b/_posts/2019-04-11-molchanov19a.md
@@ -37,7 +37,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-mondelli19a.md
+++ b/_posts/2019-04-11-mondelli19a.md
@@ -39,7 +39,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-mroueh19a.md
+++ b/_posts/2019-04-11-mroueh19a.md
@@ -33,7 +33,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-muecke19a.md
+++ b/_posts/2019-04-11-muecke19a.md
@@ -22,7 +22,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-mukhoty19a.md
+++ b/_posts/2019-04-11-mukhoty19a.md
@@ -38,7 +38,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-muller19a.md
+++ b/_posts/2019-04-11-muller19a.md
@@ -33,7 +33,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-muthukumar19a.md
+++ b/_posts/2019-04-11-muthukumar19a.md
@@ -36,7 +36,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-nacson19a.md
+++ b/_posts/2019-04-11-nacson19a.md
@@ -39,7 +39,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-nacson19b.md
+++ b/_posts/2019-04-11-nacson19b.md
@@ -45,7 +45,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-nash19a.md
+++ b/_posts/2019-04-11-nash19a.md
@@ -36,7 +36,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-natarajan19a.md
+++ b/_posts/2019-04-11-natarajan19a.md
@@ -42,7 +42,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-neykov19a.md
+++ b/_posts/2019-04-11-neykov19a.md
@@ -27,7 +27,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-neykov19b.md
+++ b/_posts/2019-04-11-neykov19b.md
@@ -28,7 +28,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-nguyen19a.md
+++ b/_posts/2019-04-11-nguyen19a.md
@@ -34,7 +34,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-nguyen19b.md
+++ b/_posts/2019-04-11-nguyen19b.md
@@ -34,7 +34,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-nikolakakis19a.md
+++ b/_posts/2019-04-11-nikolakakis19a.md
@@ -36,7 +36,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-nitanda19a.md
+++ b/_posts/2019-04-11-nitanda19a.md
@@ -36,7 +36,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-nowak19a.md
+++ b/_posts/2019-04-11-nowak19a.md
@@ -30,7 +30,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-o-connor19a.md
+++ b/_posts/2019-04-11-o-connor19a.md
@@ -37,7 +37,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-ok19a.md
+++ b/_posts/2019-04-11-ok19a.md
@@ -37,7 +37,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-okuno19a.md
+++ b/_posts/2019-04-11-okuno19a.md
@@ -34,7 +34,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-okuno19b.md
+++ b/_posts/2019-04-11-okuno19b.md
@@ -27,7 +27,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-oliveira19a.md
+++ b/_posts/2019-04-11-oliveira19a.md
@@ -33,7 +33,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-paananen19a.md
+++ b/_posts/2019-04-11-paananen19a.md
@@ -36,7 +36,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-pacheco19a.md
+++ b/_posts/2019-04-11-pacheco19a.md
@@ -31,7 +31,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-panda19a.md
+++ b/_posts/2019-04-11-panda19a.md
@@ -39,7 +39,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-pandit19a.md
+++ b/_posts/2019-04-11-pandit19a.md
@@ -41,7 +41,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-papamakarios19a.md
+++ b/_posts/2019-04-11-papamakarios19a.md
@@ -31,7 +31,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-park19a.md
+++ b/_posts/2019-04-11-park19a.md
@@ -32,7 +32,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-pasteris19a.md
+++ b/_posts/2019-04-11-pasteris19a.md
@@ -40,7 +40,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-pedregosa19a.md
+++ b/_posts/2019-04-11-pedregosa19a.md
@@ -35,7 +35,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-perrault19a.md
+++ b/_posts/2019-04-11-perrault19a.md
@@ -33,7 +33,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-pierson19a.md
+++ b/_posts/2019-04-11-pierson19a.md
@@ -42,7 +42,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-podosinnikova19a.md
+++ b/_posts/2019-04-11-podosinnikova19a.md
@@ -43,7 +43,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-poon19a.md
+++ b/_posts/2019-04-11-poon19a.md
@@ -36,7 +36,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-porrello19a.md
+++ b/_posts/2019-04-11-porrello19a.md
@@ -35,7 +35,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-putta19a.md
+++ b/_posts/2019-04-11-putta19a.md
@@ -37,7 +37,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-rabusseau19a.md
+++ b/_posts/2019-04-11-rabusseau19a.md
@@ -32,7 +32,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-ramachandran19a.md
+++ b/_posts/2019-04-11-ramachandran19a.md
@@ -35,7 +35,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-rangi19a.md
+++ b/_posts/2019-04-11-rangi19a.md
@@ -36,7 +36,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-reddi19a.md
+++ b/_posts/2019-04-11-reddi19a.md
@@ -43,7 +43,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-redko19a.md
+++ b/_posts/2019-04-11-redko19a.md
@@ -37,7 +37,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-ren19a.md
+++ b/_posts/2019-04-11-ren19a.md
@@ -32,7 +32,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-requeima19a.md
+++ b/_posts/2019-04-11-requeima19a.md
@@ -34,7 +34,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-rhodes19a.md
+++ b/_posts/2019-04-11-rhodes19a.md
@@ -32,7 +32,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-roberts19a.md
+++ b/_posts/2019-04-11-roberts19a.md
@@ -30,7 +30,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-rockova19a.md
+++ b/_posts/2019-04-11-rockova19a.md
@@ -33,7 +33,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-roos19a.md
+++ b/_posts/2019-04-11-roos19a.md
@@ -35,7 +35,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-rowland19a.md
+++ b/_posts/2019-04-11-rowland19a.md
@@ -36,7 +36,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-saad19a.md
+++ b/_posts/2019-04-11-saad19a.md
@@ -38,7 +38,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-sadeghi19a.md
+++ b/_posts/2019-04-11-sadeghi19a.md
@@ -28,7 +28,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-sadhanala19a.md
+++ b/_posts/2019-04-11-sadhanala19a.md
@@ -35,7 +35,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-saha19a.md
+++ b/_posts/2019-04-11-saha19a.md
@@ -40,7 +40,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-sahu19a.md
+++ b/_posts/2019-04-11-sahu19a.md
@@ -32,7 +32,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-sakaue19a.md
+++ b/_posts/2019-04-11-sakaue19a.md
@@ -30,7 +30,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-schmit19a.md
+++ b/_posts/2019-04-11-schmit19a.md
@@ -32,7 +32,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-schmon19a.md
+++ b/_posts/2019-04-11-schmon19a.md
@@ -29,7 +29,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-schulam19a.md
+++ b/_posts/2019-04-11-schulam19a.md
@@ -33,7 +33,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-sen19a.md
+++ b/_posts/2019-04-11-sen19a.md
@@ -35,7 +35,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-sessa19a.md
+++ b/_posts/2019-04-11-sessa19a.md
@@ -38,7 +38,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-seznec19a.md
+++ b/_posts/2019-04-11-seznec19a.md
@@ -40,7 +40,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-shaban19a.md
+++ b/_posts/2019-04-11-shaban19a.md
@@ -36,7 +36,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-shaloudegi19a.md
+++ b/_posts/2019-04-11-shaloudegi19a.md
@@ -35,7 +35,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-shekhar19a.md
+++ b/_posts/2019-04-11-shekhar19a.md
@@ -34,7 +34,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-shen19a.md
+++ b/_posts/2019-04-11-shen19a.md
@@ -35,7 +35,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-shen19b.md
+++ b/_posts/2019-04-11-shen19b.md
@@ -36,7 +36,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-shen19c.md
+++ b/_posts/2019-04-11-shen19c.md
@@ -31,7 +31,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-shi19a.md
+++ b/_posts/2019-04-11-shi19a.md
@@ -39,7 +39,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-shu19a.md
+++ b/_posts/2019-04-11-shu19a.md
@@ -38,7 +38,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-solin19a.md
+++ b/_posts/2019-04-11-solin19a.md
@@ -32,7 +32,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-soma19a.md
+++ b/_posts/2019-04-11-soma19a.md
@@ -23,7 +23,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-song19a.md
+++ b/_posts/2019-04-11-song19a.md
@@ -37,7 +37,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-song19b.md
+++ b/_posts/2019-04-11-song19b.md
@@ -39,7 +39,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-staib19a.md
+++ b/_posts/2019-04-11-staib19a.md
@@ -33,7 +33,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-stojanov19a.md
+++ b/_posts/2019-04-11-stojanov19a.md
@@ -38,7 +38,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-stojanov19b.md
+++ b/_posts/2019-04-11-stojanov19b.md
@@ -35,7 +35,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-subbaswamy19a.md
+++ b/_posts/2019-04-11-subbaswamy19a.md
@@ -36,7 +36,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-suggala19a.md
+++ b/_posts/2019-04-11-suggala19a.md
@@ -37,7 +37,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-sun19a.md
+++ b/_posts/2019-04-11-sun19a.md
@@ -34,7 +34,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-sun19b.md
+++ b/_posts/2019-04-11-sun19b.md
@@ -31,7 +31,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-sun19c.md
+++ b/_posts/2019-04-11-sun19c.md
@@ -31,7 +31,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-szabo19a.md
+++ b/_posts/2019-04-11-szabo19a.md
@@ -33,7 +33,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-taghia19a.md
+++ b/_posts/2019-04-11-taghia19a.md
@@ -34,7 +34,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-tarbouriech19a.md
+++ b/_posts/2019-04-11-tarbouriech19a.md
@@ -31,7 +31,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-tarnowski19a.md
+++ b/_posts/2019-04-11-tarnowski19a.md
@@ -42,7 +42,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-tassarotti19a.md
+++ b/_posts/2019-04-11-tassarotti19a.md
@@ -34,7 +34,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-thrampoulidis19a.md
+++ b/_posts/2019-04-11-thrampoulidis19a.md
@@ -32,7 +32,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-tian19a.md
+++ b/_posts/2019-04-11-tian19a.md
@@ -34,7 +34,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-titsias19a.md
+++ b/_posts/2019-04-11-titsias19a.md
@@ -29,7 +29,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-tompkins19a.md
+++ b/_posts/2019-04-11-tompkins19a.md
@@ -36,7 +36,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-tran19a.md
+++ b/_posts/2019-04-11-tran19a.md
@@ -35,7 +35,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-tu19a.md
+++ b/_posts/2019-04-11-tu19a.md
@@ -44,7 +44,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-uhrenholt19a.md
+++ b/_posts/2019-04-11-uhrenholt19a.md
@@ -32,7 +32,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-usmanova19a.md
+++ b/_posts/2019-04-11-usmanova19a.md
@@ -29,7 +29,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-vaicenavicius19a.md
+++ b/_posts/2019-04-11-vaicenavicius19a.md
@@ -41,7 +41,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-vashishth19a.md
+++ b/_posts/2019-04-11-vashishth19a.md
@@ -39,7 +39,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-vaswani19a.md
+++ b/_posts/2019-04-11-vaswani19a.md
@@ -38,7 +38,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-veitch19a.md
+++ b/_posts/2019-04-11-veitch19a.md
@@ -41,7 +41,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-vemula19a.md
+++ b/_posts/2019-04-11-vemula19a.md
@@ -33,7 +33,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-verma19a.md
+++ b/_posts/2019-04-11-verma19a.md
@@ -36,7 +36,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-vikram19a.md
+++ b/_posts/2019-04-11-vikram19a.md
@@ -34,7 +34,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-viswanathan19a.md
+++ b/_posts/2019-04-11-viswanathan19a.md
@@ -37,7 +37,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-wang19a.md
+++ b/_posts/2019-04-11-wang19a.md
@@ -33,7 +33,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-wang19b.md
+++ b/_posts/2019-04-11-wang19b.md
@@ -29,7 +29,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-wang19c.md
+++ b/_posts/2019-04-11-wang19c.md
@@ -31,7 +31,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-wang19d.md
+++ b/_posts/2019-04-11-wang19d.md
@@ -38,7 +38,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-wang19e.md
+++ b/_posts/2019-04-11-wang19e.md
@@ -35,7 +35,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-wang19f.md
+++ b/_posts/2019-04-11-wang19f.md
@@ -37,7 +37,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-weber19a.md
+++ b/_posts/2019-04-11-weber19a.md
@@ -37,7 +37,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-wenk19a.md
+++ b/_posts/2019-04-11-wenk19a.md
@@ -38,7 +38,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-wu19a.md
+++ b/_posts/2019-04-11-wu19a.md
@@ -31,7 +31,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-wu19b.md
+++ b/_posts/2019-04-11-wu19b.md
@@ -37,7 +37,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-wu19c.md
+++ b/_posts/2019-04-11-wu19c.md
@@ -32,7 +32,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-xie19a.md
+++ b/_posts/2019-04-11-xie19a.md
@@ -42,7 +42,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-xie19b.md
+++ b/_posts/2019-04-11-xie19b.md
@@ -34,7 +34,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-xu19a.md
+++ b/_posts/2019-04-11-xu19a.md
@@ -34,7 +34,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-yadav19a.md
+++ b/_posts/2019-04-11-yadav19a.md
@@ -42,7 +42,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-yang19a.md
+++ b/_posts/2019-04-11-yang19a.md
@@ -32,7 +32,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-yang19b.md
+++ b/_posts/2019-04-11-yang19b.md
@@ -32,7 +32,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-yang19c.md
+++ b/_posts/2019-04-11-yang19c.md
@@ -39,7 +39,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-yu19a.md
+++ b/_posts/2019-04-11-yu19a.md
@@ -35,7 +35,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-yu19b.md
+++ b/_posts/2019-04-11-yu19b.md
@@ -49,7 +49,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-yu19c.md
+++ b/_posts/2019-04-11-yu19c.md
@@ -38,7 +38,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-yu19d.md
+++ b/_posts/2019-04-11-yu19d.md
@@ -40,7 +40,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-yu19e.md
+++ b/_posts/2019-04-11-yu19e.md
@@ -45,7 +45,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-zhang19a.md
+++ b/_posts/2019-04-11-zhang19a.md
@@ -40,7 +40,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-zhang19b.md
+++ b/_posts/2019-04-11-zhang19b.md
@@ -30,7 +30,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-zhang19c.md
+++ b/_posts/2019-04-11-zhang19c.md
@@ -45,7 +45,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-zhang19d.md
+++ b/_posts/2019-04-11-zhang19d.md
@@ -42,7 +42,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-zhang19e.md
+++ b/_posts/2019-04-11-zhang19e.md
@@ -32,7 +32,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-zhang19f.md
+++ b/_posts/2019-04-11-zhang19f.md
@@ -35,7 +35,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-zhang19g.md
+++ b/_posts/2019-04-11-zhang19g.md
@@ -33,7 +33,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-zhang19h.md
+++ b/_posts/2019-04-11-zhang19h.md
@@ -32,7 +32,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-zhao19a.md
+++ b/_posts/2019-04-11-zhao19a.md
@@ -31,7 +31,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-zhe19a.md
+++ b/_posts/2019-04-11-zhe19a.md
@@ -36,7 +36,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-zhou19a.md
+++ b/_posts/2019-04-11-zhou19a.md
@@ -38,7 +38,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-zhou19b.md
+++ b/_posts/2019-04-11-zhou19b.md
@@ -42,7 +42,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-zhou19c.md
+++ b/_posts/2019-04-11-zhou19c.md
@@ -37,7 +37,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-zhu19a.md
+++ b/_posts/2019-04-11-zhu19a.md
@@ -41,7 +41,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-zhu19b.md
+++ b/_posts/2019-04-11-zhu19b.md
@@ -37,7 +37,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-zhu19c.md
+++ b/_posts/2019-04-11-zhu19c.md
@@ -30,7 +30,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-zhu19d.md
+++ b/_posts/2019-04-11-zhu19d.md
@@ -39,7 +39,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-zimmert19a.md
+++ b/_posts/2019-04-11-zimmert19a.md
@@ -32,7 +32,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:

--- a/_posts/2019-04-11-zou19a.md
+++ b/_posts/2019-04-11-zou19a.md
@@ -33,7 +33,7 @@ author:
 date: 2019-04-11
 address: 
 publisher: PMLR
-container-title: Proceedings of Machine Learning Research
+container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics
 volume: '89'
 genre: inproceedings
 issued:


### PR DESCRIPTION
Resolve #10. 

I ran `sed` command to replace `container-title` under `_posts/`:

```bash
$ sed -i "" 's/container-title: Proceedings of Machine Learning Research/container-title: Proceedings of the Twenty-Second International Conference on Artificial Intelligence and Statistics/g'
```

## Double check

The number of files under `_posts/` is `360`  which is the same as the number of changed file in this pull request.
